### PR TITLE
Fix use of characterSpacing API

### DIFF
--- a/sketch-sf-font-fixer.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/sketch-sf-font-fixer.sketchplugin/Contents/Sketch/script.cocoascript
@@ -17,7 +17,7 @@ var adjustUITextFontForLayer = function(layer) {
                             19: -0.49 };
 
     if (characterSpacings[fontSize] != nil) {
-      [layer setCharacterSpacing:characterSpacings[fontSize]];
+      layer.characterSpacing = characterSpacings[fontSize];
     }
 };
 
@@ -88,7 +88,7 @@ var adjustUIDisplayFontForLayer = function(layer) {
                             81: -0.084752 };
                             
     if (characterSpacings[fontSize] != nil) {
-      [layer setCharacterSpacing:characterSpacings[fontSize]];
+      layer.characterSpacing = characterSpacings[fontSize];
     }
 };
 


### PR DESCRIPTION
This change seems to restore the plugin's functionality. Tested on Sketch 41.2.