### PR TITLE
Add support for native Sketch plugin updates

### DIFF
--- a/sketch-sf-font-fixer.sketchplugin/Contents/Sketch/manifest.json
+++ b/sketch-sf-font-fixer.sketchplugin/Contents/Sketch/manifest.json
@@ -15,7 +15,7 @@
       "fixSelectedLayers",
     ]
   },
-  "appcast": "https://raw.githubusercontent.com/kylehickinson/Sketch-SF-UI-Font-Fixer/master/appcast.xml",
+  "appcast": "https://api.sketchpacks.com/v1/plugins/com.kylehickinson.sf-fix-fonts/appcast",
   "identifier" : "com.kylehickinson.sf-fix-fonts",
   "version" : "1.0",
   "description" : "A plugin which adjusts character spacing of SF UI Text/SF UI Display text layers based on its font size",


### PR DESCRIPTION
Further reading: https://docs.sketchpacks.com/developers/publishing/providing-plugin-updates.html

Basically, you won't have to manually update your appcast XML feed once using the Sketchpacks Appcast API endpoint. Integrating with [Sketchpacks Relay](https://github.com/apps/sketchpacks-relay) will update your appcast feed in real-time after each release is published.